### PR TITLE
Import fixes for rxjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-absinthe-upload-link",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A network interface for Apollo that enables file-uploading to Absinthe back ends.",
   "main": "src/index.js",
   "repository": "https://github.com/bytewitchcraft/apollo-absinthe-upload-link",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
 import { HttpLink } from 'apollo-link-http'
 import { ApolloLink, concat } from 'apollo-link'
 import { printAST } from 'apollo-client'
-import { ajax } from 'rxjs/observable/dom/ajax'
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/dom/ajax';
+import 'rxjs/add/operator/map';
 import { pipe, append, join } from 'ramda'
 
 const isObject = value => value !== null && typeof value === 'object'
@@ -52,7 +54,7 @@ const createUploadMiddleware = ({ uri }) =>
         formData.append('variables', JSON.stringify(variables))
         files.forEach(({ name, file }) => formData.append(name, file))
 
-        return ajax({
+        return Observable.ajax({
           url: uri,
           body: formData,
           method: 'POST',


### PR DESCRIPTION
This pull request is done in order to fix the possible error `Object(...)(...).map is not a function`.

For what we understand, without the use of rxjs, or redux-observable in other sections of a project, the `map` operator is never imported, and can't be called. This is just a really simple fix, but we hope it helps.

Resources: 
https://github.com/redux-observable/redux-observable/issues/29