### PR TITLE
Add react-native support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
   "presets": ["env"],
   "plugins": [
+    "transform-class-properties",
     "transform-object-rest-spread"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.2.1",
     "babel-jest": "^22.2.0",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "eslint": "^4.14.0",

--- a/src/index.js
+++ b/src/index.js
@@ -31,3 +31,5 @@ export const createUploadMiddleware = ({ uri, headers }) =>
 
 export const createLink = opts =>
   concat(createUploadMiddleware(opts), new HttpLink(opts))
+
+export { ReactNativeFile } from './validators'

--- a/src/validators.js
+++ b/src/validators.js
@@ -3,4 +3,50 @@ export const isFileList = value =>
   typeof FileList !== 'undefined' && value instanceof FileList
 
 export const isUploadFile = value =>
-  typeof File !== 'undefined' && value instanceof File
+  (typeof File !== 'undefined' && value instanceof File) || value instanceof ReactNativeFile
+
+/**
+ * A React Native FormData file object.
+ * @see {@link https://github.com/facebook/react-native/blob/v0.45.1/Libraries/Network/FormData.js#L34}
+ * @typedef {Object} ReactNativeFileObject
+ * @property {String} uri - File system path.
+ * @property {String} [type] - File content type.
+ * @property {String} [name] - File name.
+ */
+
+/**
+ * A React Native file.
+ */
+export class ReactNativeFile {
+  /**
+   * Constructs a new file.
+   * @param {ReactNativeFileObject} file
+   * @example
+   * const file = new ReactNativeFile({
+   *  uri: uriFromCameraRoll,
+   *  type: 'image/jpeg',
+   *  name: 'photo.jpg'
+   * })
+   */
+  constructor({ uri, type, name }) {
+    this.uri = uri
+    this.type = type
+    this.name = name
+  }
+
+  /**
+   * Creates an array of file instances.
+   * @param {ReactNativeFileObject[]} files
+   * @example
+   * const files = ReactNativeFile.list([{
+   *   uri: uriFromCameraRoll1,
+   *   type: 'image/jpeg',
+   *   name: 'photo-1.jpg'
+   * }, {
+   *   uri: uriFromCameraRoll2,
+   *   type: 'image/jpeg',
+   *   name: 'photo-2.jpg'
+   * }])
+   */
+  static list = files => files.map(file => new ReactNativeFile(file))
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -525,6 +525,10 @@ babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
 
+babel-plugin-syntax-class-properties@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
+
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
@@ -544,6 +548,15 @@ babel-plugin-transform-async-to-generator@^6.22.0:
     babel-helper-remap-async-to-generator "^6.24.1"
     babel-plugin-syntax-async-functions "^6.8.0"
     babel-runtime "^6.22.0"
+
+babel-plugin-transform-class-properties@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz#6a79763ea61d33d36f37b611aa9def81a81b46ac"
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-plugin-syntax-class-properties "^6.8.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
 
 babel-plugin-transform-es2015-arrow-functions@^6.22.0:
   version "6.22.0"


### PR DESCRIPTION
This adds support for react-native by including a `ReactNativeFile` class to mark file like objects for extraction (shamelessly stolen from [extract-files](https://github.com/jaydenseric/extract-files)).

In practice it looks something like this:

```
import { ReactNativeFile } from 'apollo-absinthe-upload-link'
import gql from 'graphql-tag'

// Apollo Client instance
import client from './apollo'

const file = new ReactNativeFile({
  uri: '…',
  type: 'image/jpeg',
  name: 'photo.jpg'
})

client.mutate({
  mutation: gql`
    mutation($file: Upload!) {
      uploadFile(file: $file) {
        id
      }
    }
  `,
  variables: { file }
})
```

You might also consider adding [extract-files](https://github.com/jaydenseric/extract-files) as a dependency and using it to extract files similar to [apollo-upload-client](https://github.com/jaydenseric/apollo-upload-client).