### PR TITLE
Support Blob

### DIFF
--- a/src/validators.js
+++ b/src/validators.js
@@ -1,9 +1,11 @@
 export const isObject = value => value !== null && typeof value === 'object'
+
 export const isFileList = value =>
   typeof FileList !== 'undefined' && value instanceof FileList
 
 export const isUploadFile = value =>
   (typeof File !== 'undefined' && value instanceof File) ||
+  (typeof Blob !== 'undefined' && value instanceof Blob) ||
   value instanceof ReactNativeFile
 
 /**


### PR DESCRIPTION
I've been using this lib with `File` objects, but today I had to use with a `Blob` and it just ignored the file on the request.

Considering that `apollo-upload-client` supports Blob (https://github.com/jaydenseric/apollo-upload-client#blob), I think apollo-absinthe-upload-link could also support it.

I don't know how I can write a test for this specific scenario, though.