### PR TITLE
introduce customizable fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,33 @@ const client = new ApolloClient({
 });
 ```
 
+### Custom fetch
+
+You can use the fetch option when creating an apollo-absinthe-upload-link to do a lot of custom networking. This is useful if you want to modify the request based on the calculated headers or calculate the uri based on the operation.
+
+```js
+import ApolloClient from "apollo-client";
+import { createLink } from "apollo-absinthe-upload-link";
+
+const customFetch = (uri, options) => {
+  const { header } = Hawk.client.header(
+    "http://example.com:8000/resource/1?b=1&a=2",
+    "POST",
+    { credentials: credentials, ext: "some-app-data" }
+  );
+  options.headers.Authorization = header;
+  return fetch(uri, options);
+};
+
+const headers = { authorization: 1234 } 
+const client = new ApolloClient({
+    link: createLink({
+        uri: "/graphql"
+    }),
+    headers,
+    fetch: customFetch
+});
+```
 
 ### Usage with React Native
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "apollo-client": "^2.0.4",
     "apollo-link": "^1.0.7",
     "apollo-link-http": "^1.3.2",
+    "apollo-link-http-common": "^0.2.4",
     "graphql": "0.11.3",
     "ramda": "^0.25.0",
     "rxjs": "5.4.3"
@@ -29,7 +30,10 @@
     "babel-preset-env": "^1.6.1",
     "eslint": "^4.14.0",
     "eslint-plugin-prettier": "^2.4.0",
+    "fetch-mock": "^6.5.2",
+    "graphql-tag": "^2.9.2",
     "jest": "^22.2.1",
+    "node-fetch": "^2.2.0",
     "prettier": "1.9.2",
     "regenerator-runtime": "^0.11.1",
     "rimraf": "^2.6.2"

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,10 @@ import { printAST } from 'apollo-client'
 import request from './request'
 import extractFiles from './extractFiles'
 import { isObject } from './validators'
+import { parseAndCheckHttpResponse } from 'apollo-link-http-common'
+import { Observable } from 'apollo-link'
 
-export const createUploadMiddleware = ({ uri, headers }) =>
+export const createUploadMiddleware = ({ uri, headers, fetch }) =>
   new ApolloLink((operation, forward) => {
     if (typeof FormData !== 'undefined' && isObject(operation.variables)) {
       const { variables, files } = extractFiles(operation.variables)
@@ -18,11 +20,39 @@ export const createUploadMiddleware = ({ uri, headers }) =>
         formData.append('variables', JSON.stringify(variables))
         files.forEach(({ name, file }) => formData.append(name, file))
 
-        return request({
-          uri,
-          body: formData,
-          headers: { ...contextHeaders, ...headers },
-        })
+        // is there a custom fetch? then use it
+        if (fetch) {
+          return new Observable(observer => {
+            fetch(uri, {
+              method: 'POST',
+              headers: { ...contextHeaders, ...headers },
+              body: formData,
+            })
+              .then(response => {
+                operation.setContext({ response })
+                return response
+              })
+              .then(parseAndCheckHttpResponse(operation))
+              .then(result => {
+                // we have data and can send it to back up the link chain
+                observer.next(result)
+                observer.complete()
+                return result
+              })
+              .catch(err => {
+                if (err.result && err.result.errors && err.result.data) {
+                  observer.next(err.result)
+                }
+                observer.error(err)
+              })
+          })
+        } else {
+          return request({
+            uri,
+            body: formData,
+            headers: { ...contextHeaders, ...headers },
+          })
+        }
       }
     }
 


### PR DESCRIPTION
hi @bytewitchcraft!

Thanks for this really awesome link. For our purposes we need to switch out the fetch-Function, because we need to check accessTokens and maybe refresh them in-flight.

This PR adds the possibility to provide a custom fetch function instead of using `Observable.ajax`