### PR TITLE
Allow to pass opts.httpLink

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,25 @@ const client = new ApolloClient({
 });
 ```
 
+### Custom HttpLink
+
+By default we are using [apollo-link-http](https://www.npmjs.com/package/apollo-link-http) as default HTTP link library. But there are other possible HTTP links available such as [apollo-link-batch-http](https://www.npmjs.com/package/apollo-link-batch-http). To pass custom `HttpLink` constructor you can do so with `opts.httpLink`
+
+
+```js
+import ApolloClient from "apollo-client";
+import { createLink } from "apollo-absinthe-upload-link";
+import { BatchHttpLink } from "apollo-link-batch-http";
+
+const client = new ApolloClient({
+    link: createLink({
+        uri: "/graphql",
+        httpLink: BatchHttpLink,
+    })
+});
+```
+
+
 ### Usage with React Native
 
 Substitute [`File`](https://developer.mozilla.org/en/docs/Web/API/File) with [`ReactNativeFile`](https://github.com/bytewitchcraft/apollo-absinthe-upload-link/blob/master/src/validators.js):

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,14 @@ import { isObject } from './validators'
 import { parseAndCheckHttpResponse } from 'apollo-link-http-common'
 import { Observable } from 'apollo-link'
 
+export const createHttpLink = opts => fallbackLink => {
+  if (opts.httpLink) {
+    return new opts.httpLink(opts)
+  } else {
+    return new fallbackLink(opts)
+  }
+}
+
 export const createUploadMiddleware = ({ uri, headers, fetch }) =>
   new ApolloLink((operation, forward) => {
     if (typeof FormData !== 'undefined' && isObject(operation.variables)) {
@@ -60,6 +68,6 @@ export const createUploadMiddleware = ({ uri, headers, fetch }) =>
   })
 
 export const createLink = opts =>
-  concat(createUploadMiddleware(opts), new HttpLink(opts))
+  concat(createUploadMiddleware(opts), createHttpLink(opts)(HttpLink))
 
 export { ReactNativeFile } from './validators'


### PR DESCRIPTION
Quick feature to allow passing `opts.httpLink` instead of using default `apollo-link-http` (I needed that for replacing it with `batch` http link) WDYT? It is worth to merge? Or should I keep my fork :) Thanks 