### PR TITLE
Add credentials to opts in request when credentials are "include"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import { isObject } from './validators'
 import { parseAndCheckHttpResponse } from 'apollo-link-http-common'
 import { Observable } from 'apollo-link'
 
-export const createUploadMiddleware = ({ uri, headers, fetch }) =>
+export const createUploadMiddleware = ({ uri, headers, fetch, credentials }) =>
   new ApolloLink((operation, forward) => {
     if (typeof FormData !== 'undefined' && isObject(operation.variables)) {
       const { variables, files } = extractFiles(operation.variables)
@@ -53,10 +53,14 @@ export const createUploadMiddleware = ({ uri, headers, fetch }) =>
               })
           })
         } else {
+          const withCredentials = credentials === "include";
+          
           return request({
             uri,
             body: formData,
             headers: Object.assign({}, contextHeaders, headers),
+            withCredentials,
+            crossDomain: withCredentials
           })
         }
       }

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ export const createUploadMiddleware = ({ uri, headers, fetch, credentials }) =>
           method: 'POST',
           headers: Object.assign({}, contextHeaders, headers),
           body: formData,
+          credentials,
         }
 
         // add context.fetchOptions to fetch options

--- a/src/index.js
+++ b/src/index.js
@@ -53,14 +53,13 @@ export const createUploadMiddleware = ({ uri, headers, fetch, credentials }) =>
               })
           })
         } else {
-          const withCredentials = credentials === "include";
-          
+          const withCredentials = credentials === 'include'
           return request({
             uri,
             body: formData,
             headers: Object.assign({}, contextHeaders, headers),
             withCredentials,
-            crossDomain: withCredentials
+            crossDomain: withCredentials,
           })
         }
       }

--- a/src/request.js
+++ b/src/request.js
@@ -12,6 +12,8 @@ const request = opts =>
     body: opts.body,
     method: 'POST',
     headers: opts.headers,
+    withCredentials: opts.withCredentials,
+    crossDomain: opts.crossDomain
   }).pipe(map(({ response }) => response))
 
 export default request

--- a/src/request.js
+++ b/src/request.js
@@ -13,7 +13,7 @@ const request = opts =>
     method: 'POST',
     headers: opts.headers,
     withCredentials: opts.withCredentials,
-    crossDomain: opts.crossDomain
+    crossDomain: opts.crossDomain,
   }).pipe(map(({ response }) => response))
 
 export default request


### PR DESCRIPTION
This pull request fix a bug in createUploadMiddleware who is ignoring credentials, this error happens when we use creatingLink in apolloClient as e.g:
```
const httpLink = createLink({
  credentials: "include",
...
});
```
 With the changes this now accepts credentials to requests. 