### PR TITLE
Changes module to lib folder to fetch compiled version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.5.0",
   "description": "A network interface for Apollo that enables file-uploading to Absinthe back ends.",
   "main": "lib/index.js",
-  "module": "src/index.js",
+  "module": "lib/index.js",
   "repository": "https://github.com/bytewitchcraft/apollo-absinthe-upload-link",
   "author": "Ihor Katkov",
   "license": "MIT",


### PR DESCRIPTION
<img width="488" alt="Screenshot 2019-04-27 at 06 19 38" src="https://user-images.githubusercontent.com/293785/56844159-9255a880-68b4-11e9-8bb7-a05e430f3877.png">

Points `module` to transpiled version. Webpack can include the right version. Otherwise getting an error since some browsers cannot support some modern JS features. 

