### PR TITLE
add initial TypeScript declarations

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,2 @@
+import { ApolloLink, HttpOptions } from "@apollo/client";
+export const createLink: (linkOptions?: HttpOptions) => ApolloLink;


### PR DESCRIPTION
I was integrating your lib into our TypeScript app and needed type declarations. I would love to see this in your next release.